### PR TITLE
Set completed time when saving response to local, not when decorating

### DIFF
--- a/src/apps/irs_record_point/store.js
+++ b/src/apps/irs_record_point/store.js
@@ -127,6 +127,8 @@ export default {
     create_response_local: async (context, response) => {
       try {
         if (Object.keys(response.location.coords).length === 0) Raven.captureException(new Error('Coords is empty'))
+        // update the most recent 'form_completed_at' timestamp
+        response.most_recent_form_completed_time = new Date()
         await controller.create_local(response)
         context.commit('create_response', response)
         context.commit('root:set_snackbar', {message: 'Created record'}, {root: true})

--- a/src/lib/models/response/model.js
+++ b/src/lib/models/response/model.js
@@ -67,9 +67,6 @@ export class Response {
       decorated.initial_form_completion_duration_seconds = moment().diff(decorated.recorded_on, 'seconds')
     }
 
-    // update the most recent 'form_completed_at' timestamp
-    decorated.most_recent_form_completed_time = new Date()
-
     return decorated
   }
 


### PR DESCRIPTION
Now it sets the completed time right when the response is being saved. Just after the user clicks 'save'.