### PR TITLE
Don’t zoom in if there is nothing to zoom in to

### DIFF
--- a/src/apps/irs_monitor/pages/map/dashboard-map.vue
+++ b/src/apps/irs_monitor/pages/map/dashboard-map.vue
@@ -107,6 +107,7 @@
         })
       },
       fit_bounds() {
+        if (!this.bbox.length) return 
         this._map.fitBounds(this.bbox, {padding: 20})
       },
       redraw_layers() {
@@ -133,6 +134,7 @@
       },
       zoom_to_features () {
         // Zoom to features
+        if (!this._aggregated_responses_fc.features.length) return 
         this.bbox = bbox(this._aggregated_responses_fc)
         this.bind_popup(this.selected_layer)
       },


### PR DESCRIPTION
First don't set bbox when there are no aggregated responses.

Second, don't zoom into a an empty bbox.