### PR TITLE
Don’t render chart if there is no data

### DIFF
--- a/src/apps/irs_monitor/pages/charts/chart.vue
+++ b/src/apps/irs_monitor/pages/charts/chart.vue
@@ -55,6 +55,7 @@
     methods: {
       get_chart_data() {
         if (!this.has_responses) {
+          if (this._chart) Plotly.purge(this._chart)
           return false
         }
 


### PR DESCRIPTION
We are _already_ doing something similar in `render_chart`, but we forgot to do this here.