### PR TITLE
391 incorrect coverage calculations

### DIFF
--- a/src/apps/irs_monitor/lib/decorate_geodata.js
+++ b/src/apps/irs_monitor/lib/decorate_geodata.js
@@ -33,12 +33,23 @@ export function decorate_geodata({binned_responses, targets, aggregations, optio
     // Include only targets, by id
     const target_ids = targets.map(t => t.id)
     const geodata_for_targets = all_features.features.filter(f => target_ids.includes(f.properties[id_field]))
-
-    selected_geodata_level_fc.features = geodata_for_targets
-
+    
     // Copy enumeration property(s) from targets back onto geodata
-    const denominator_fields = get_denominator_fields()
-    debugger
+    const geodata_for_targets_with_denominators = geodata_for_targets.map(target => {
+      const found_target = targets.find(t => t.id === target.properties[id_field])
+      if (!found_target) return target
+      
+      const denominator_fields = get_denominator_fields()
+      
+      for (const denominator_field in denominator_fields) {
+        const field = denominator_fields[denominator_field]
+        target.properties[field] = found_target[denominator_field]
+      }
+      return target
+    })
+
+    selected_geodata_level_fc.features = geodata_for_targets_with_denominators
+
   } else {
     // Use all current geodata
     selected_geodata_level_fc = all_features


### PR DESCRIPTION
Last commit copies all denominators from targets onto geodata.

@TNgidi Could you test this out and confirm it works?

With this PR we can now ensure the historical accuracy of plans and records. 