### PR TITLE
[WIP] ensure sw_update_available is false when app starts

### DIFF
--- a/src/config/configure_application.js
+++ b/src/config/configure_application.js
@@ -72,6 +72,7 @@ export async function configure_application(instance_config) {
   // Make Vuex#$store and replace rehydrated (by vuex-persistedstate) instance_config with received instance_config
   // (Required for the app)
   const store = create_store(instance_config, instance_applets_stores_and_routes.stores)
+  store.commit('root:set_sw_update_available', false)
   store.commit('root:set_instance_config', instance_config)
 
   document.addEventListener("show-update-available", e => {


### PR DESCRIPTION
When you set a value to the same value, no change is triggered. The `sw_update_available` property was being persisted in the Vue state (`vuex-persistedstate`). If there had been a previous update, this value would be `true`, so when the next update sets it to `true`, there's no response from the UI.

This needs some more good testing (not via Netlify, but locally with multiple builds).

cc @mosaic141688 @Nicolaidavies for info