### PR TITLE
Rewording

### DIFF
--- a/src/apps/irs_record_point/pages/location_selection.vue
+++ b/src/apps/irs_record_point/pages/location_selection.vue
@@ -123,10 +123,11 @@
           .sort((a, b) => a.name.localeCompare(b.name))
       },
       top_placeholder() {
-        return `OPTIONAL: Select ${this.singularise(get_next_level_up_from_planning_level().name)} to filter ${get_planning_level_name()} list below`
+
+        return `OPTIONAL: Select to filter ${get_planning_level_name()}`
       },
       bottom_placeholder() {
-        return `REQUIRED: Select ${this.singularise(get_planning_level_name())}`
+        return `REQUIRED: Select from ${get_planning_level_name()}`
       }
     },
     watch: {


### PR DESCRIPTION
The problem was that for zwe-mat* the application would crash when loading a the record component.
The cause was and reason why it affected only zwe-mat* is that it had one level in the geodata, so the  `singularise` function got called with a undefined value making it to crash. The simple solution is to use a different wording and avoid the  `singularise` function for now.