### PR TITLE
hotfix/451-Invalid-regular-expression

### DIFF
--- a/src/apps/debug/pages/building_debug.vue
+++ b/src/apps/debug/pages/building_debug.vue
@@ -38,6 +38,7 @@
   import bbox from '@turf/bbox'
   import moment from 'moment-mini'
   import mapboxgl from 'mapbox-gl'
+  import {escapeRegExp} from 'lodash'
 
   import {get_current_position} from 'lib/helpers/location_helper.js'
   import {basic_map} from 'lib/helpers/basic_map'
@@ -190,7 +191,7 @@
           // Stop matching everything with a blank input
           this.matching_building_ids = []
         } else {
-          const regex = new RegExp(this.building_typed + "$")
+          const regex = new RegExp(escapeRegExp(this.building_typed) + "$")
           this.matching_building_ids = this._buildings_geojson.features.filter(building => {
             const id = building.properties[this.selected_building_field]
             return regex.test(id)

--- a/src/apps/irs_record_point/pages/list.vue
+++ b/src/apps/irs_record_point/pages/list.vue
@@ -81,7 +81,7 @@
   import download from 'downloadjs'
   import moment from 'moment-mini'
   import {mapState} from 'vuex'
-  import {flatten, get} from 'lodash'
+  import {flatten, get, escapeRegExp} from 'lodash'
 
   import controls from 'components/controls.vue'
   import {ResponseController} from 'lib/models/response/controller'
@@ -118,7 +118,7 @@
         if (!this.responses.length) return []
         if (!this.search_string) return this.responses
 
-        const regex = new RegExp(this.search_string.toLowerCase(), 'i')
+        const regex = new RegExp(escapeRegExp(this.search_string.toLowerCase()), 'i')
 
         return this.responses
           .filter(r => {

--- a/src/apps/irs_record_point/pages/location_selection.vue
+++ b/src/apps/irs_record_point/pages/location_selection.vue
@@ -71,7 +71,7 @@
 
 <script>
   import Multiselect from 'vue-multiselect'
-  import {get, has, uniq} from 'lodash'
+  import {get, has, uniq, escapeRegExp} from 'lodash'
 
   import {
     get_record_location_selection,
@@ -118,7 +118,7 @@
           })
           .filter(l => {
             if (!this.subarea_query) return true
-            return new RegExp(this.subarea_query, 'i').test(l.name)
+            return new RegExp(escapeRegExp(this.subarea_query), 'i').test(l.name)
           })
           .sort((a, b) => a.name.localeCompare(b.name))
       },


### PR DESCRIPTION
The application was crashing when you type in a `\` because the `\` was treated as an escape character. This pull request solves it by escaping string from input to be used in a regex using lodash `escapeRegExp` function