### PR TITLE
Feature/459 gps optional

### DIFF
--- a/src/apps/irs_record_point/pages/record.vue
+++ b/src/apps/irs_record_point/pages/record.vue
@@ -331,7 +331,7 @@
         }
       },
       validate(response) {
-        this.validation_result = this._validator.validate(response)
+        this.validation_result = this._validator.validate(response, this.instance_config)
         if (this.validation_result_empty) this.show_validation_result = false
 
         // Events

--- a/src/lib/models/response/controller.js
+++ b/src/lib/models/response/controller.js
@@ -128,9 +128,6 @@ export class ResponseController {
   }
 
   async create_response_local(response) {
-    // Log an unusual error
-    if (Object.keys(response.location.coords).length === 0) Raven.captureException(new Error('Coords is empty'))
-
     // update the most recent 'form_completed_at' timestamp
     response.most_recent_form_completed_time = new Date()
 
@@ -138,9 +135,6 @@ export class ResponseController {
   }
 
   async update_response_local(response) {
-    // Log an unusual error
-    if (Object.keys(response.location.coords).length === 0) Raven.captureException(new Error('Coords is empty'))
-
     // update the most recent 'form_completed_at' timestamp
     response.most_recent_form_completed_time = new Date()
 

--- a/src/lib/models/response/model.js
+++ b/src/lib/models/response/model.js
@@ -48,7 +48,7 @@ export class Response {
   }
 
   is_ready_to_send() {
-    return (this.model.form_data !== null) && (this.model.location.selection !== null)
+    return this.model.form_data !== null
   }
 
   decorate_for_sending() { // TODO: @refac Rename to not conflict with 'decorators'

--- a/src/lib/models/response/model.js
+++ b/src/lib/models/response/model.js
@@ -48,7 +48,7 @@ export class Response {
   }
 
   is_ready_to_send() {
-    return (this.model.form_data !== null) && (this.model.location.coords !== null) && (this.model.location.selection !== null)
+    return (this.model.form_data !== null) && (this.model.location.selection !== null)
   }
 
   decorate_for_sending() { // TODO: @refac Rename to not conflict with 'decorators'

--- a/src/lib/models/response/validations/validations.js
+++ b/src/lib/models/response/validations/validations.js
@@ -16,14 +16,14 @@ export class Validator {
     const location_coords = get(response, 'location.coords', null)
     const location_selection = get(response, 'location.selection', null)
 
-    const location_result = this._validate_location(location_coords)
+    const location_coords_result = this._validate_location_coords(location_coords)
     const location_selection_result = this._validate_location_selection(location_selection)
 
     // Validate main form_data / response object
     const survey_results = this._validate_form_data(response.form_data)
 
     // Collect the results from each type together
-    const results = [].concat(location_result, location_selection_result, survey_results)
+    const results = [].concat(location_coords_result, location_selection_result, survey_results)
 
     // Collect only the {status: 'failed'} results - everything else is for information/debugging
     const failing_results = results.filter(v => v.status === 'failed')
@@ -56,7 +56,7 @@ export class Validator {
     return survey_validations
   }
 
-  _validate_location(coords) {
+  _validate_location_coords(coords) {
     const validation = {
       name: 'no_geo_location',
       message: 'Problem with Geolocation (GPS coordinates)',

--- a/src/lib/models/response/validations/validations.js
+++ b/src/lib/models/response/validations/validations.js
@@ -10,13 +10,14 @@ export class Validator {
     return this
   }
 
-  validate(response) {
+  validate(response, instance_config) {
+    const location_coords_optional = instance_config.applets.irs_record_point.location_coords_optional
     // Validate location - only if location.selection has been set (i.e. expect coords set)
 
     const location_coords = get(response, 'location.coords', null)
     const location_selection = get(response, 'location.selection', null)
 
-    const location_coords_result = this._validate_location_coords(location_coords)
+    const location_coords_result = this._validate_location_coords(location_coords, location_coords_optional)
     const location_selection_result = this._validate_location_selection(location_selection)
 
     // Validate main form_data / response object
@@ -56,7 +57,7 @@ export class Validator {
     return survey_validations
   }
 
-  _validate_location_coords(coords) {
+  _validate_location_coords(coords, location_coords_optional) {
     const validation = {
       name: 'no_geo_location',
       message: 'Problem with Geolocation (GPS coordinates)',
@@ -65,10 +66,7 @@ export class Validator {
       status: 'failed'
     }
 
-    // get from config
-    const coords_are_optional = true 
-
-    if (coords_are_optional) {
+    if (location_coords_optional) {
       return {...validation, status: 'passed'}
     }
 

--- a/src/lib/models/response/validations/validations.js
+++ b/src/lib/models/response/validations/validations.js
@@ -65,8 +65,20 @@ export class Validator {
       status: 'failed'
     }
 
-    if (coords === null) return validation
-    if (!CoordsSchema(coords)) return validation
+    // get from config
+    const coords_are_optional = true 
+
+    if (coords_are_optional) {
+      return {...validation, status: 'passed'}
+    }
+
+    if (coords === null) {
+      return validation
+    }
+
+    if (!CoordsSchema(coords)) {
+      return validation
+    }
 
     return {...validation, status: 'passed'}
 

--- a/src/lib/models/response/validations/validations.js
+++ b/src/lib/models/response/validations/validations.js
@@ -11,8 +11,9 @@ export class Validator {
   }
 
   validate(response, instance_config) {
-    const gps_coords_required = instance_config.applets.irs_record_point.gps_coords_required
-    const location_selection_required = instance_config.applets.irs_record_point.location_selection_required
+    // location_selection and gps are required by default
+    const gps_coords_required = get(instance_config.applets.irs_record_point, 'gps_coords_required', true);
+    const location_selection_required = get(instance_config.applets.irs_record_point, 'location_selection_required', true);
     // Validate location - only if location.selection has been set (i.e. expect coords set)
 
     const location_coords = get(response, 'location.coords', null)


### PR DESCRIPTION
We now have two properties under `irs_record_point`:

- location_selection_required
- gps_coords_required


We need to update the configurations for all instances to include those two properties and make sure they are both set to `true` to maintain current behaviour.
 